### PR TITLE
Update deployment target from burr to azul.tailnet-003a.ts.net

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           RSYNC_PASSWORD: ${{ secrets.RSYNC_PASSWORD }}
         run: |
-          rsync -avz --delete ./www/ rsync://wwwdeploy@burr.tailnet-003a.ts.net/timer.dzdz.cz/
+          rsync -avz --delete ./www/ rsync://wwwdeploy@azul.tailnet-003a.ts.net/timer.dzdz.cz/
 
   ntfy:
     name: Ntfy


### PR DESCRIPTION
# Update deployment target from burr to azul.tailnet-003a.ts.net

## Summary
Updates the rsync deployment target hostname from `burr.tailnet-003a.ts.net` to `azul.tailnet-003a.ts.net` in the GitHub Actions deploy workflow. This migrates the deployment destination to a new server while keeping all other configuration unchanged (module path `/timer.dzdz.cz/`, rsync options, authentication, Tailscale setup).

This is part of a coordinated migration across 8 repositories. Seven have already been merged successfully (10foot6in, arborwx-static, clock, computers.ninja, fuckingtimezones.com, jsonview, start.dzdz.cz).

## Review & Testing Checklist for Human
- [ ] Verify `azul.tailnet-003a.ts.net` has rsync daemon configured with module path `/timer.dzdz.cz/` matching burr's configuration
- [ ] Confirm the `RSYNC_PASSWORD` secret works with azul's rsync daemon
- [ ] After merge, monitor the Deploy workflow run on main to confirm successful deployment to azul

### Notes
- Merging will immediately trigger a production deployment via the workflow's `on: push` to main trigger
- Cannot test the rsync connection in CI since the deploy step only runs on main branch pushes
- The seven previously merged repos in this migration deployed successfully, which indicates azul infrastructure is working

---

**Link to Devin run**: https://app.devin.ai/sessions/77c390486c6e4c368a9f2e486d472c0e  
**Requested by**: Chris Dzombak (chris@dzombak.com) / @cdzombak

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment infrastructure configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->